### PR TITLE
Integrate rmcp MCP client service

### DIFF
--- a/codex-rs/Cargo.lock
+++ b/codex-rs/Cargo.lock
@@ -334,6 +334,115 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "axum"
+version = "0.7.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edca88bc138befd0323b20752846e6587272d3b03b0343c8ea28a6f819e6e71f"
+dependencies = [
+ "async-trait",
+ "axum-core 0.4.5",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "itoa",
+ "matchit 0.7.3",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustversion",
+ "serde",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "axum"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "021e862c184ae977658b36c4500f7feac3221ca5da43e3f25bd04ab6c79a29b5"
+dependencies = [
+ "axum-core 0.5.2",
+ "bytes",
+ "form_urlencoded",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "itoa",
+ "matchit 0.8.4",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustversion",
+ "serde",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09f2bd6146b97ae3359fa0cc6d6b376d9539582c7b4220f041a33ec24c226199"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "rustversion",
+ "sync_wrapper",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68464cd0412f486726fb3373129ef5d2993f90c34bc2bc1c1e9943b2f4fc7ca6"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "rustversion",
+ "sync_wrapper",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
 name = "backtrace"
 version = "0.3.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -487,6 +596,12 @@ name = "cfg_aliases"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chrono"
@@ -839,7 +954,12 @@ name = "codex-mcp-client"
 version = "0.0.0"
 dependencies = [
  "anyhow",
+ "axum 0.7.9",
+ "clap",
  "mcp-types",
+ "pretty_assertions",
+ "reqwest",
+ "rmcp",
  "serde",
  "serde_json",
  "tokio",
@@ -1243,8 +1363,18 @@ version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
 dependencies = [
- "darling_core",
- "darling_macro",
+ "darling_core 0.20.11",
+ "darling_macro 0.20.11",
+]
+
+[[package]]
+name = "darling"
+version = "0.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9cdf337090841a411e2a7f3deb9187445851f91b309c0c0a29e05f74a00a48c0"
+dependencies = [
+ "darling_core 0.21.3",
+ "darling_macro 0.21.3",
 ]
 
 [[package]]
@@ -1262,12 +1392,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling_core"
+version = "0.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1247195ecd7e3c85f83c8d2a366e4210d588e802133e1e355180a9870b517ea4"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim 0.11.1",
+ "syn 2.0.104",
+]
+
+[[package]]
 name = "darling_macro"
 version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
- "darling_core",
+ "darling_core 0.20.11",
+ "quote",
+ "syn 2.0.104",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
+dependencies = [
+ "darling_core 0.21.3",
  "quote",
  "syn 2.0.104",
 ]
@@ -1949,8 +2104,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi 0.11.1+wasi-snapshot-preview1",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1960,9 +2117,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi",
  "wasi 0.14.2+wasi-0.2.4",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -2159,6 +2318,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -2468,7 +2628,7 @@ version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "435d80800b936787d62688c927b6490e887c7ef5ff9ce922c6c6050fca75eb9a"
 dependencies = [
- "darling",
+ "darling 0.20.11",
  "indoc",
  "proc-macro2",
  "quote",
@@ -2760,6 +2920,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
+
+[[package]]
 name = "lsp-types"
 version = "0.94.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2786,6 +2952,18 @@ checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
 dependencies = [
  "regex-automata",
 ]
+
+[[package]]
+name = "matchit"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
+
+[[package]]
+name = "matchit"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
 name = "mcp-types"
@@ -2938,7 +3116,19 @@ checksum = "ab2156c4fce2f8df6c499cc1c763e4394b7482525bf2a9701c9d79d215f519e4"
 dependencies = [
  "bitflags 2.9.1",
  "cfg-if",
- "cfg_aliases",
+ "cfg_aliases 0.1.1",
+ "libc",
+]
+
+[[package]]
+name = "nix"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
+dependencies = [
+ "bitflags 2.9.1",
+ "cfg-if",
+ "cfg_aliases 0.2.1",
  "libc",
 ]
 
@@ -3364,7 +3554,7 @@ dependencies = [
  "lazy_static",
  "libc",
  "log",
- "nix",
+ "nix 0.28.0",
  "serial2",
  "shared_library",
  "shell-words",
@@ -3453,6 +3643,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "process-wrap"
+version = "8.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3ef4f2f0422f23a82ec9f628ea2acd12871c81a9362b02c43c1aa86acfc3ba1"
+dependencies = [
+ "futures",
+ "indexmap 2.10.0",
+ "nix 0.30.1",
+ "tokio",
+ "tracing",
+ "windows",
+]
+
+[[package]]
 name = "pulldown-cmark"
 version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3493,6 +3697,61 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8927b0664f5c5a98265138b7e3f90aa19a6b21353182469ace36d4ac527b7b1b"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "quinn"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+dependencies = [
+ "bytes",
+ "cfg_aliases 0.2.1",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls",
+ "socket2",
+ "thiserror 2.0.16",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1906b49b0c3bc04b5fe5d86a77925ae6524a19b816ae38ce1e426255f1d8a31"
+dependencies = [
+ "bytes",
+ "getrandom 0.3.3",
+ "lru-slab",
+ "rand",
+ "ring",
+ "rustc-hash",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror 2.0.16",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+dependencies = [
+ "cfg_aliases 0.2.1",
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3687,6 +3946,8 @@ dependencies = [
  "native-tls",
  "percent-encoding",
  "pin-project-lite",
+ "quinn",
+ "rustls",
  "rustls-pki-types",
  "serde",
  "serde_json",
@@ -3694,6 +3955,7 @@ dependencies = [
  "sync_wrapper",
  "tokio",
  "tokio-native-tls",
+ "tokio-rustls",
  "tokio-util",
  "tower",
  "tower-http",
@@ -3703,6 +3965,7 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -3720,10 +3983,62 @@ dependencies = [
 ]
 
 [[package]]
+name = "rmcp"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "534fd1cd0601e798ac30545ff2b7f4a62c6f14edd4aaed1cc5eb1e85f69f09af"
+dependencies = [
+ "axum 0.8.4",
+ "base64",
+ "bytes",
+ "chrono",
+ "futures",
+ "http",
+ "http-body",
+ "http-body-util",
+ "paste",
+ "pin-project-lite",
+ "process-wrap",
+ "rand",
+ "reqwest",
+ "rmcp-macros",
+ "schemars 1.0.4",
+ "serde",
+ "serde_json",
+ "sse-stream",
+ "thiserror 2.0.16",
+ "tokio",
+ "tokio-stream",
+ "tokio-util",
+ "tower-service",
+ "tracing",
+ "uuid",
+]
+
+[[package]]
+name = "rmcp-macros"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ba777eb0e5f53a757e36f0e287441da0ab766564ba7201600eeb92a4753022e"
+dependencies = [
+ "darling 0.21.3",
+ "proc-macro2",
+ "quote",
+ "serde_json",
+ "syn 2.0.104",
+]
+
+[[package]]
 name = "rustc-demangle"
 version = "0.1.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "989e6739f80c4ad5b13e0fd7fe89531180375b18520cc8c82080e4dc4035b84f"
+
+[[package]]
+name = "rustc-hash"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
 
 [[package]]
 name = "rustix"
@@ -3758,6 +4073,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2491382039b29b9b11ff08b76ff6c97cf287671dbb74f0be44bda389fffe9bd1"
 dependencies = [
  "once_cell",
+ "ring",
  "rustls-pki-types",
  "rustls-webpki",
  "subtle",
@@ -3770,6 +4086,7 @@ version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "229a4a4c221013e7e1f1a043678c5cc39fe5171437c88fb47151a21e6f5b5c79"
 dependencies = [
+ "web-time",
  "zeroize",
 ]
 
@@ -3804,7 +4121,7 @@ dependencies = [
  "libc",
  "log",
  "memchr",
- "nix",
+ "nix 0.28.0",
  "radix_trie",
  "unicode-segmentation",
  "unicode-width 0.1.14",
@@ -3885,7 +4202,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fbf2ae1b8bc8e02df939598064d22402220cd5bbcca1c76f7d6a310974d5615"
 dependencies = [
  "dyn-clone",
- "schemars_derive",
+ "schemars_derive 0.8.22",
  "serde",
  "serde_json",
 ]
@@ -3908,8 +4225,10 @@ version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "82d20c4491bc164fa2f6c5d44565947a52ad80b9505d8e36f8d54c27c739fcd0"
 dependencies = [
+ "chrono",
  "dyn-clone",
  "ref-cast",
+ "schemars_derive 1.0.4",
  "serde",
  "serde_json",
 ]
@@ -3919,6 +4238,18 @@ name = "schemars_derive"
 version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32e265784ad618884abaea0600a9adf15393368d840e0222d101a072f3f7534d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde_derive_internals",
+ "syn 2.0.104",
+]
+
+[[package]]
+name = "schemars_derive"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33d020396d1d138dc19f1165df7545479dcd58d93810dc5d646a16e55abefa80"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4020,6 +4351,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_path_to_error"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10a9ff822e371bb5403e391ecd83e182e0e77ba7f6fe0160b795797109d1b457"
+dependencies = [
+ "itoa",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
 name = "serde_repr"
 version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4077,7 +4419,7 @@ version = "3.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de90945e6565ce0d9a25098082ed4ee4002e047cb59892c318d66821e14bb30f"
 dependencies = [
- "darling",
+ "darling 0.20.11",
  "proc-macro2",
  "quote",
  "syn 2.0.104",
@@ -4227,6 +4569,19 @@ checksum = "233504af464074f9d066d7b5416c5f9b894a5862a6506e306f7b816cdd6f1807"
 dependencies = [
  "libc",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "sse-stream"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb4dc4d33c68ec1f27d386b5610a351922656e1fdf5c05bbaad930cd1519479a"
+dependencies = [
+ "bytes",
+ "futures-util",
+ "http-body",
+ "http-body-util",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -4685,6 +5040,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinyvec"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa5fdc3bce6191a1dbc8c02d5c8bffcf557bafa17c124c5264a458f1b0613fa"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
 name = "tokio"
 version = "1.47.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4837,6 +5207,7 @@ dependencies = [
  "tokio",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -5297,6 +5668,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "webbrowser"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5310,6 +5691,15 @@ dependencies = [
  "objc2-foundation",
  "url",
  "web-sys",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e8983c3ab33d6fb807cfcdad2491c4ea8cbc8ed839181c7dfd9c67c83e261b2"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -5368,6 +5758,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "windows"
+version = "0.61.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
+dependencies = [
+ "windows-collections",
+ "windows-core",
+ "windows-future",
+ "windows-link 0.1.3",
+ "windows-numerics",
+]
+
+[[package]]
+name = "windows-collections"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8"
+dependencies = [
+ "windows-core",
+]
+
+[[package]]
 name = "windows-core"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5378,6 +5790,17 @@ dependencies = [
  "windows-link 0.1.3",
  "windows-result",
  "windows-strings",
+]
+
+[[package]]
+name = "windows-future"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e"
+dependencies = [
+ "windows-core",
+ "windows-link 0.1.3",
+ "windows-threading",
 ]
 
 [[package]]
@@ -5413,6 +5836,16 @@ name = "windows-link"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "45e46c0661abb7180e7b9c281db115305d49ca1709ab8242adf09666d2173c65"
+
+[[package]]
+name = "windows-numerics"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
+dependencies = [
+ "windows-core",
+ "windows-link 0.1.3",
+]
 
 [[package]]
 name = "windows-registry"
@@ -5539,6 +5972,15 @@ dependencies = [
  "windows_x86_64_gnu 0.53.0",
  "windows_x86_64_gnullvm 0.53.0",
  "windows_x86_64_msvc 0.53.0",
+]
+
+[[package]]
+name = "windows-threading"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b66463ad2e0ea3bbf808b7f1d371311c80e115c0b71d60efc142cafbcfb057a6"
+dependencies = [
+ "windows-link 0.1.3",
 ]
 
 [[package]]

--- a/codex-rs/core/src/mcp_connection_manager.rs
+++ b/codex-rs/core/src/mcp_connection_manager.rs
@@ -16,14 +16,13 @@ use anyhow::Context;
 use anyhow::Result;
 use anyhow::anyhow;
 use codex_mcp_client::McpClient;
-use mcp_types::ClientCapabilities;
-use mcp_types::Implementation;
 use mcp_types::Tool;
 
-use serde_json::json;
 use sha1::Digest;
 use sha1::Sha1;
 use tokio::task::JoinSet;
+use tokio::time::timeout;
+use tracing::debug;
 use tracing::info;
 use tracing::warn;
 
@@ -89,6 +88,8 @@ struct ManagedClient {
     client: Arc<McpClient>,
     startup_timeout: Duration,
     tool_timeout: Option<Duration>,
+    #[allow(dead_code)]
+    _notification_task: tokio::task::JoinHandle<()>,
 }
 
 /// A thin wrapper around a set of running [`McpClient`] instances.
@@ -144,50 +145,18 @@ impl McpConnectionManager {
                 let McpServerConfig {
                     command, args, env, ..
                 } = cfg;
-                let client_res = McpClient::new_stdio_client(
+                let spawn_future = McpClient::spawn_stdio(
                     command.into(),
                     args.into_iter().map(OsString::from).collect(),
                     env,
-                )
-                .await;
-                match client_res {
-                    Ok(client) => {
-                        // Initialize the client.
-                        let params = mcp_types::InitializeRequestParams {
-                            capabilities: ClientCapabilities {
-                                experimental: None,
-                                roots: None,
-                                sampling: None,
-                                // https://modelcontextprotocol.io/specification/2025-06-18/client/elicitation#capabilities
-                                // indicates this should be an empty object.
-                                elicitation: Some(json!({})),
-                            },
-                            client_info: Implementation {
-                                name: "codex-mcp-client".to_owned(),
-                                version: env!("CARGO_PKG_VERSION").to_owned(),
-                                title: Some("Codex".into()),
-                                // This field is used by Codex when it is an MCP
-                                // server: it should not be used when Codex is
-                                // an MCP client.
-                                user_agent: None,
-                            },
-                            protocol_version: mcp_types::MCP_SCHEMA_VERSION.to_owned(),
-                        };
-                        let initialize_notification_params = None;
-                        let init_result = client
-                            .initialize(
-                                params,
-                                initialize_notification_params,
-                                Some(startup_timeout),
-                            )
-                            .await;
-                        (
-                            (server_name, tool_timeout),
-                            init_result.map(|_| (client, startup_timeout)),
-                        )
-                    }
-                    Err(e) => ((server_name, tool_timeout), Err(e.into())),
-                }
+                    startup_timeout,
+                );
+                let client_res = timeout(startup_timeout, spawn_future).await;
+                let client_res = match client_res {
+                    Ok(result) => result.map(|client| (client, startup_timeout)),
+                    Err(_) => Err(anyhow!("timeout while starting MCP server `{server_name}`")),
+                };
+                ((server_name, tool_timeout), client_res)
             });
         }
 
@@ -204,12 +173,35 @@ impl McpConnectionManager {
 
             match client_res {
                 Ok((client, startup_timeout)) => {
+                    let client = Arc::new(client);
+                    let mut notifications = client.subscribe_notifications();
+                    let server_name_clone = server_name.clone();
+                    let notification_task = tokio::spawn(async move {
+                        while let Ok(notification) = notifications.recv().await {
+                            match serde_json::to_value(&notification) {
+                                Ok(value) => {
+                                    debug!(
+                                        server = %server_name_clone,
+                                        notification = %value,
+                                        "received MCP notification"
+                                    );
+                                }
+                                Err(_) => {
+                                    debug!(
+                                        server = %server_name_clone,
+                                        "received MCP notification"
+                                    );
+                                }
+                            }
+                        }
+                    });
                     clients.insert(
                         server_name,
                         ManagedClient {
-                            client: Arc::new(client),
+                            client,
                             startup_timeout,
                             tool_timeout: Some(tool_timeout),
+                            _notification_task: notification_task,
                         },
                     );
                 }
@@ -281,7 +273,7 @@ async fn list_all_tools(clients: &HashMap<String, ManagedClient>) -> Result<Vec<
         let client_clone = managed_client.client.clone();
         let startup_timeout = managed_client.startup_timeout;
         join_set.spawn(async move {
-            let res = client_clone.list_tools(None, Some(startup_timeout)).await;
+            let res = timeout(startup_timeout, client_clone.list_all_tools()).await;
             (server_name_cloned, res)
         });
     }
@@ -296,14 +288,19 @@ async fn list_all_tools(clients: &HashMap<String, ManagedClient>) -> Result<Vec<
             continue;
         };
 
-        let list_result = if let Ok(result) = list_result {
-            result
-        } else {
-            warn!("Failed to list tools for MCP server '{server_name}': {list_result:#?}");
-            continue;
+        let tools = match list_result {
+            Ok(Ok(tools)) => tools,
+            Ok(Err(err)) => {
+                warn!("Failed to list tools for MCP server '{server_name}': {err:#}");
+                continue;
+            }
+            Err(err) => {
+                warn!("Failed to list tools for MCP server '{server_name}': {err:#}");
+                continue;
+            }
         };
 
-        for tool in list_result.tools {
+        for tool in tools {
             let tool_info = ToolInfo {
                 server_name: server_name.clone(),
                 tool_name: tool.name.clone(),

--- a/codex-rs/mcp-client/Cargo.toml
+++ b/codex-rs/mcp-client/Cargo.toml
@@ -8,11 +8,22 @@ workspace = true
 
 [dependencies]
 anyhow = { workspace = true }
+clap = { workspace = true, features = ["derive"] }
 mcp-types = { workspace = true }
+reqwest = { workspace = true, features = ["json", "rustls-tls", "stream"] }
+rmcp = { version = "0.7", default-features = false, features = [
+    "base64",
+    "client",
+    "macros",
+    "reqwest",
+    "schemars",
+    "server",
+    "transport-child-process",
+    "transport-sse-client-reqwest",
+    "transport-streamable-http-client-reqwest",
+] }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
-tracing = { workspace = true, features = ["log"] }
-tracing-subscriber = { workspace = true, features = ["fmt", "env-filter"] }
 tokio = { workspace = true, features = [
     "io-util",
     "macros",
@@ -21,3 +32,21 @@ tokio = { workspace = true, features = [
     "sync",
     "time",
 ] }
+tracing = { workspace = true, features = ["log"] }
+tracing-subscriber = { workspace = true, features = ["env-filter", "fmt"] }
+
+[dev-dependencies]
+anyhow = { workspace = true }
+axum = "0.7"
+rmcp = { version = "0.7", default-features = false, features = [
+    "base64",
+    "macros",
+    "schemars",
+    "server",
+    "transport-streamable-http-server",
+    "transport-streamable-http-server-session",
+    "transport-sse-server",
+] }
+pretty_assertions = { workspace = true }
+serde_json = { workspace = true }
+tokio = { workspace = true, features = ["macros", "rt-multi-thread", "time"] }

--- a/codex-rs/mcp-client/src/main.rs
+++ b/codex-rs/mcp-client/src/main.rs
@@ -1,34 +1,86 @@
 //! Simple command-line utility to exercise `McpClient`.
-//!
-//! Example usage:
-//!
-//! ```bash
-//! cargo run -p codex-mcp-client -- `codex-mcp-server`
-//! ```
-//!
-//! Any additional arguments after the first one are forwarded to the spawned
-//! program. The utility connects, issues a `tools/list` request and prints the
-//! server's response as pretty JSON.
 
+use std::collections::HashMap;
 use std::ffi::OsString;
 use std::time::Duration;
 
 use anyhow::Context;
 use anyhow::Result;
+use clap::ArgAction;
+use clap::Parser;
 use codex_mcp_client::McpClient;
-use mcp_types::ClientCapabilities;
-use mcp_types::Implementation;
-use mcp_types::InitializeRequestParams;
-use mcp_types::ListToolsRequestParams;
-use mcp_types::MCP_SCHEMA_VERSION;
+use reqwest::header::HeaderMap;
+use reqwest::header::HeaderName;
+use reqwest::header::HeaderValue;
 use tracing_subscriber::EnvFilter;
+
+#[derive(Parser, Debug)]
+#[command(
+    name = "codex-mcp-client",
+    about = "Interact with MCP servers over stdio or HTTP"
+)]
+struct Cli {
+    /// Connect to an MCP server over HTTP instead of spawning a subprocess.
+    #[arg(long)]
+    http: Option<String>,
+
+    /// Additional HTTP headers to include when connecting over HTTP.
+    #[arg(long = "header", value_parser = parse_header, value_name = "NAME:VALUE")]
+    headers: Vec<(HeaderName, HeaderValue)>,
+
+    /// Additional environment variables to pass to the spawned MCP server.
+    #[arg(long = "env", value_parser = parse_key_val, value_name = "NAME=VALUE")]
+    env: Vec<(String, String)>,
+
+    /// Timeout (seconds) for establishing the connection.
+    #[arg(long, default_value_t = 10)]
+    timeout_secs: u64,
+
+    /// Program (and optional arguments) to run when using stdio transport.
+    #[arg(value_name = "PROGRAM", trailing_var_arg = true, action = ArgAction::Append)]
+    args: Vec<OsString>,
+}
 
 #[tokio::main]
 async fn main() -> Result<()> {
+    init_tracing();
+    let cli = Cli::parse();
+    let timeout = Duration::from_secs(cli.timeout_secs);
+
+    let client = if let Some(url) = cli.http {
+        let mut header_map = HeaderMap::new();
+        for (name, value) in cli.headers {
+            header_map.insert(name, value);
+        }
+        McpClient::connect_http(url, None, Some(header_map), None, timeout)
+            .await
+            .context("failed to connect to HTTP MCP server")?
+    } else {
+        let mut args = cli.args;
+        if args.is_empty() {
+            anyhow::bail!(
+                "Usage: codex-mcp-client <program> [args..]\n\nExample: codex-mcp-client codex-mcp-server"
+            );
+        }
+        let program = args.remove(0);
+        let env: HashMap<String, String> = cli.env.into_iter().collect();
+        McpClient::spawn_stdio(program, args, Some(env), timeout)
+            .await
+            .context("failed to spawn subprocess")?
+    };
+
+    let tools = client
+        .list_all_tools()
+        .await
+        .context("tools/list request failed")?;
+    println!("{}", serde_json::to_string_pretty(&tools)?);
+
+    Ok(())
+}
+
+fn init_tracing() {
     let default_level = "debug";
     let _ = tracing_subscriber::fmt()
-        // Fallback to the `default_level` log filter if the environment
-        // variable is not set _or_ contains an invalid value
         .with_env_filter(
             EnvFilter::try_from_default_env()
                 .or_else(|_| EnvFilter::try_new(default_level))
@@ -36,56 +88,22 @@ async fn main() -> Result<()> {
         )
         .with_writer(std::io::stderr)
         .try_init();
+}
 
-    // Collect command-line arguments excluding the program name itself.
-    let mut args: Vec<OsString> = std::env::args_os().skip(1).collect();
+fn parse_key_val(s: &str) -> Result<(String, String)> {
+    let (key, value) = s
+        .split_once('=')
+        .ok_or_else(|| anyhow::anyhow!("expected NAME=VALUE, got {s}"))?;
+    Ok((key.to_owned(), value.to_owned()))
+}
 
-    if args.is_empty() || args[0] == "--help" || args[0] == "-h" {
-        eprintln!("Usage: mcp-client <program> [args..]\n\nExample: mcp-client codex-mcp-server");
-        std::process::exit(1);
-    }
-    let original_args = args.clone();
-
-    // Spawn the subprocess and connect the client.
-    let program = args.remove(0);
-    let env = None;
-    let client = McpClient::new_stdio_client(program, args, env)
-        .await
-        .with_context(|| format!("failed to spawn subprocess: {original_args:?}"))?;
-
-    let params = InitializeRequestParams {
-        capabilities: ClientCapabilities {
-            experimental: None,
-            roots: None,
-            sampling: None,
-            elicitation: None,
-        },
-        client_info: Implementation {
-            name: "codex-mcp-client".to_owned(),
-            version: env!("CARGO_PKG_VERSION").to_owned(),
-            title: Some("Codex".to_string()),
-            // This field is used by Codex when it is an MCP server: it should
-            // not be used when Codex is an MCP client.
-            user_agent: None,
-        },
-        protocol_version: MCP_SCHEMA_VERSION.to_owned(),
-    };
-    let initialize_notification_params = None;
-    let timeout = Some(Duration::from_secs(10));
-    let response = client
-        .initialize(params, initialize_notification_params, timeout)
-        .await?;
-    eprintln!("initialize response: {response:?}");
-
-    // Issue `tools/list` request (no params).
-    let timeout = None;
-    let tools = client
-        .list_tools(None::<ListToolsRequestParams>, timeout)
-        .await
-        .context("tools/list request failed")?;
-
-    // Print the result in a human readable form.
-    println!("{}", serde_json::to_string_pretty(&tools)?);
-
-    Ok(())
+fn parse_header(s: &str) -> Result<(HeaderName, HeaderValue)> {
+    let (name, value) = s
+        .split_once(':')
+        .ok_or_else(|| anyhow::anyhow!("expected NAME:VALUE, got {s}"))?;
+    let header_name = HeaderName::try_from(name.trim())
+        .map_err(|err| anyhow::anyhow!("invalid header name `{name}`: {err}"))?;
+    let header_value = HeaderValue::try_from(value.trim())
+        .map_err(|err| anyhow::anyhow!("invalid header value `{value}`: {err}"))?;
+    Ok((header_name, header_value))
 }

--- a/codex-rs/mcp-client/src/mcp_client.rs
+++ b/codex-rs/mcp-client/src/mcp_client.rs
@@ -303,7 +303,7 @@ fn codex_client_info() -> ClientInfo {
 
 fn parse_protocol_version(version: &str) -> ProtocolVersion {
     serde_json::from_str::<ProtocolVersion>(&format!("\"{version}\""))
-        .unwrap_or(ProtocolVersion::LATEST)
+        .expect("hardcoded MCP_SCHEMA_VERSION should be valid")
 }
 
 fn convert_value<T, U>(value: T) -> Result<U>

--- a/codex-rs/mcp-client/src/mcp_client.rs
+++ b/codex-rs/mcp-client/src/mcp_client.rs
@@ -158,21 +158,12 @@ impl McpClient {
                 .with_context(|| format!("invalid arguments for tool `{tool_name}`"))?,
         };
 
-        let result = if let Some(timeout_duration) = timeout_duration {
-            let request = CallToolRequest::new(params.clone());
-            let handle = self
-                .peer()
-                .send_request_with_option(
-                    ClientRequest::CallToolRequest(request),
-                    PeerRequestOptions {
-                        timeout: Some(timeout_duration),
-                        meta: None,
-                    },
-                )
-                .await
-                .map_err(|err| anyhow!(err))?;
-            match handle.await_response().await.map_err(|err| anyhow!(err))? {
-                ServerResult::CallToolResult(result) => result,
+            match tokio::time::timeout(timeout_duration, handle.await_response()).await {
+                Ok(Ok(ServerResult::CallToolResult(result))) => result,
+                Ok(Ok(other)) => return Err(anyhow!("unexpected response variant: {other:?}")),
+                Ok(Err(err)) => return Err(anyhow!(err)),
+                Err(_) => return Err(anyhow!("request timed out")),
+            }
                 other => return Err(anyhow!("unexpected response variant: {other:?}")),
             }
         } else {

--- a/codex-rs/mcp-client/src/mcp_client.rs
+++ b/codex-rs/mcp-client/src/mcp_client.rs
@@ -1,406 +1,326 @@
-//! A minimal async client for the Model Context Protocol (MCP).
+//! Client utilities for interacting with Model Context Protocol (MCP) servers.
 //!
-//! The client is intentionally lightweight – it is only capable of:
-//!   1. Spawning a subprocess that launches a conforming MCP server that
-//!      communicates over stdio.
-//!   2. Sending MCP requests and pairing them with their corresponding
-//!      responses.
-//!   3. Offering a convenience helper for the common `tools/list` request.
-//!
-//! The crate hides all JSON‐RPC framing details behind a typed API. Users
-//! interact with the [`ModelContextProtocolRequest`] trait from `mcp-types` to
-//! issue requests and receive strongly-typed results.
+//! This module wraps the `rmcp` SDK so Codex can rely on the upstream
+//! JSON-RPC handling, transports, and helpers instead of maintaining bespoke
+//! plumbing.
 
 use std::collections::HashMap;
 use std::ffi::OsString;
 use std::sync::Arc;
-use std::sync::atomic::AtomicI64;
-use std::sync::atomic::Ordering;
 use std::time::Duration;
 
 use anyhow::Context;
 use anyhow::Result;
 use anyhow::anyhow;
-use mcp_types::CallToolRequest;
-use mcp_types::CallToolRequestParams;
-use mcp_types::InitializeRequest;
-use mcp_types::InitializeRequestParams;
-use mcp_types::InitializedNotification;
-use mcp_types::JSONRPC_VERSION;
-use mcp_types::JSONRPCMessage;
-use mcp_types::JSONRPCNotification;
-use mcp_types::JSONRPCRequest;
-use mcp_types::JSONRPCResponse;
-use mcp_types::ListToolsRequest;
-use mcp_types::ListToolsRequestParams;
-use mcp_types::ListToolsResult;
-use mcp_types::ModelContextProtocolNotification;
-use mcp_types::ModelContextProtocolRequest;
-use mcp_types::RequestId;
+use rmcp::ErrorData as McpError;
+use rmcp::model::CallToolRequest;
+use rmcp::model::CallToolRequestParam;
+use rmcp::model::ClientCapabilities;
+use rmcp::model::ClientInfo;
+use rmcp::model::ClientNotification;
+use rmcp::model::ClientRequest;
+use rmcp::model::ClientResult;
+use rmcp::model::CreateElicitationResult;
+use rmcp::model::CreateMessageRequestMethod;
+use rmcp::model::ElicitationAction;
+use rmcp::model::ElicitationCapability;
+use rmcp::model::Implementation;
+use rmcp::model::JsonObject;
+use rmcp::model::ListRootsResult;
+use rmcp::model::ProtocolVersion;
+use rmcp::model::ServerNotification;
+use rmcp::model::ServerRequest;
+use rmcp::model::ServerResult;
+use rmcp::service::NotificationContext;
+use rmcp::service::Peer;
+use rmcp::service::PeerRequestOptions;
+use rmcp::service::RequestContext;
+use rmcp::service::RoleClient;
+use rmcp::service::RunningService;
+use rmcp::service::Service;
+use rmcp::service::ServiceExt;
+use rmcp::transport::ConfigureCommandExt;
+use rmcp::transport::IntoTransport;
+use rmcp::transport::StreamableHttpClientTransport;
+use rmcp::transport::TokioChildProcess;
+use rmcp::transport::streamable_http_client::StreamableHttpClientTransportConfig;
 use serde::Serialize;
 use serde::de::DeserializeOwned;
-use tokio::io::AsyncBufReadExt;
-use tokio::io::AsyncWriteExt;
-use tokio::io::BufReader;
-use tokio::process::Command;
-use tokio::sync::Mutex;
-use tokio::sync::mpsc;
-use tokio::sync::oneshot;
-use tokio::time;
+use tokio::sync::broadcast;
+use tokio::time::timeout;
 use tracing::debug;
-use tracing::error;
-use tracing::info;
-use tracing::warn;
 
-/// Capacity of the bounded channels used for transporting messages between the
-/// client API and the IO tasks.
-const CHANNEL_CAPACITY: usize = 128;
+const NOTIFICATION_CHANNEL_CAPACITY: usize = 128;
 
-/// Internal representation of a pending request sender.
-type PendingSender = oneshot::Sender<JSONRPCMessage>;
-
-/// A running MCP client instance.
+/// A running MCP client backed by the upstream `rmcp` SDK.
+#[derive(Clone)]
 pub struct McpClient {
-    /// Retain this child process until the client is dropped. The Tokio runtime
-    /// will make a "best effort" to reap the process after it exits, but it is
-    /// not a guarantee. See the `kill_on_drop` documentation for details.
-    #[allow(dead_code)]
-    child: tokio::process::Child,
+    inner: Arc<McpClientInner>,
+}
 
-    /// Channel for sending JSON-RPC messages *to* the background writer task.
-    outgoing_tx: mpsc::Sender<JSONRPCMessage>,
-
-    /// Map of `request.id -> oneshot::Sender` used to dispatch responses back
-    /// to the originating caller.
-    pending: Arc<Mutex<HashMap<i64, PendingSender>>>,
-
-    /// Monotonically increasing counter used to generate request IDs.
-    id_counter: AtomicI64,
+struct McpClientInner {
+    running_service: RunningService<RoleClient, CodexClientService>,
+    notifications: broadcast::Sender<ServerNotification>,
 }
 
 impl McpClient {
-    /// Spawn the given command and establish an MCP session over its STDIO.
-    /// Caller is responsible for sending the `initialize` request. See
-    /// [`initialize`](Self::initialize) for details.
-    pub async fn new_stdio_client(
+    /// Spawn an MCP server as a subprocess and connect over stdio.
+    pub async fn spawn_stdio(
         program: OsString,
         args: Vec<OsString>,
         env: Option<HashMap<String, String>>,
-    ) -> std::io::Result<Self> {
-        let mut child = Command::new(program)
+        timeout_duration: Duration,
+    ) -> Result<Self> {
+        let mut command = tokio::process::Command::new(program);
+        command
             .args(args)
             .env_clear()
-            .envs(create_env_for_mcp_server(env))
-            .stdin(std::process::Stdio::piped())
-            .stdout(std::process::Stdio::piped())
-            .stderr(std::process::Stdio::null())
-            // As noted in the `kill_on_drop` documentation, the Tokio runtime makes
-            // a "best effort" to reap-after-exit to avoid zombie processes, but it
-            // is not a guarantee.
-            .kill_on_drop(true)
-            .spawn()?;
+            .envs(create_env_for_mcp_server(env));
 
-        let stdin = child
-            .stdin
-            .take()
-            .ok_or_else(|| std::io::Error::other("failed to capture child stdin"))?;
-        let stdout = child
-            .stdout
-            .take()
-            .ok_or_else(|| std::io::Error::other("failed to capture child stdout"))?;
+        let transport = TokioChildProcess::new(command.configure(|cmd| {
+            cmd.stdin(std::process::Stdio::piped());
+            cmd.stdout(std::process::Stdio::piped());
+            cmd.stderr(std::process::Stdio::inherit());
+            cmd.kill_on_drop(true);
+        }))?;
 
-        let (outgoing_tx, mut outgoing_rx) = mpsc::channel::<JSONRPCMessage>(CHANNEL_CAPACITY);
-        let pending: Arc<Mutex<HashMap<i64, PendingSender>>> = Arc::new(Mutex::new(HashMap::new()));
-
-        // Spawn writer task. It listens on the `outgoing_rx` channel and
-        // writes messages to the child's STDIN.
-        let writer_handle = {
-            let mut stdin = stdin;
-            tokio::spawn(async move {
-                while let Some(msg) = outgoing_rx.recv().await {
-                    match serde_json::to_string(&msg) {
-                        Ok(json) => {
-                            debug!("MCP message to server: {json}");
-                            if stdin.write_all(json.as_bytes()).await.is_err() {
-                                error!("failed to write message to child stdin");
-                                break;
-                            }
-                            if stdin.write_all(b"\n").await.is_err() {
-                                error!("failed to write newline to child stdin");
-                                break;
-                            }
-                            // No explicit flush needed on a pipe; write_all is sufficient.
-                        }
-                        Err(e) => error!("failed to serialize JSONRPCMessage: {e}"),
-                    }
-                }
-            })
-        };
-
-        // Spawn reader task. It reads line-delimited JSON from the child's
-        // STDOUT and dispatches responses to the pending map.
-        let reader_handle = {
-            let pending = pending.clone();
-            let mut lines = BufReader::new(stdout).lines();
-
-            tokio::spawn(async move {
-                while let Ok(Some(line)) = lines.next_line().await {
-                    debug!("MCP message from server: {line}");
-                    match serde_json::from_str::<JSONRPCMessage>(&line) {
-                        Ok(JSONRPCMessage::Response(resp)) => {
-                            Self::dispatch_response(resp, &pending).await;
-                        }
-                        Ok(JSONRPCMessage::Error(err)) => {
-                            Self::dispatch_error(err, &pending).await;
-                        }
-                        Ok(JSONRPCMessage::Notification(JSONRPCNotification { .. })) => {
-                            // For now we only log server-initiated notifications.
-                            info!("<- notification: {}", line);
-                        }
-                        Ok(other) => {
-                            // Batch responses and requests are currently not
-                            // expected from the server – log and ignore.
-                            info!("<- unhandled message: {:?}", other);
-                        }
-                        Err(e) => {
-                            error!("failed to deserialize JSONRPCMessage: {e}; line = {}", line)
-                        }
-                    }
-                }
-            })
-        };
-
-        // We intentionally *detach* the tasks. They will keep running in the
-        // background as long as their respective resources (channels/stdin/
-        // stdout) are alive. Dropping `McpClient` cancels the tasks due to
-        // dropped resources.
-        let _ = (writer_handle, reader_handle);
-
-        Ok(Self {
-            child,
-            outgoing_tx,
-            pending,
-            id_counter: AtomicI64::new(1),
-        })
+        Self::start_with_transport(transport, timeout_duration).await
     }
 
-    /// Send an arbitrary MCP request and await the typed result.
-    ///
-    /// If `timeout` is `None` the call waits indefinitely. If `Some(duration)`
-    /// is supplied and no response is received within the given period, a
-    /// timeout error is returned.
-    pub async fn send_request<R>(
-        &self,
-        params: R::Params,
-        timeout: Option<Duration>,
-    ) -> Result<R::Result>
-    where
-        R: ModelContextProtocolRequest,
-        R::Params: Serialize,
-        R::Result: DeserializeOwned,
-    {
-        // Create a new unique ID.
-        let id = self.id_counter.fetch_add(1, Ordering::SeqCst);
-        let request_id = RequestId::Integer(id);
+    /// Connect to an MCP server over HTTP+SSE using the streamable transport.
+    pub async fn connect_http(
+        uri: impl Into<String>,
+        client: Option<reqwest::Client>,
+        headers: Option<reqwest::header::HeaderMap>,
+        transport_config: Option<StreamableHttpClientTransportConfig>,
+        timeout_duration: Duration,
+    ) -> Result<Self> {
+        use reqwest::header::AUTHORIZATION;
+        use std::sync::Arc as StdArc;
 
-        // Serialize params -> JSON. For many request types `Params` is
-        // `Option<T>` and `None` should be encoded as *absence* of the field.
-        let params_json = serde_json::to_value(&params)?;
-        let params_field = if params_json.is_null() {
-            None
-        } else {
-            Some(params_json)
-        };
+        let uri_string = uri.into();
+        let uri_arc: StdArc<str> = StdArc::from(uri_string.as_str());
 
-        let jsonrpc_request = JSONRPCRequest {
-            id: request_id.clone(),
-            jsonrpc: JSONRPC_VERSION.to_string(),
-            method: R::METHOD.to_string(),
-            params: params_field,
-        };
+        let mut config = transport_config
+            .unwrap_or_else(|| StreamableHttpClientTransportConfig::with_uri(uri_arc.clone()));
+        config.uri = uri_arc.clone();
 
-        let message = JSONRPCMessage::Request(jsonrpc_request);
-
-        // oneshot channel for the response.
-        let (tx, rx) = oneshot::channel();
-
-        // Register in pending map *before* sending the message so a race where
-        // the response arrives immediately cannot be lost.
+        if let Some(value) = headers
+            .as_ref()
+            .and_then(|map| map.get(AUTHORIZATION))
+            .and_then(|value| value.to_str().ok())
         {
-            let mut guard = self.pending.lock().await;
-            guard.insert(id, tx);
+            config = config.auth_header(value.to_owned());
         }
 
-        // Send to writer task.
-        if self.outgoing_tx.send(message).await.is_err() {
-            return Err(anyhow!(
-                "failed to send message to writer task - channel closed"
-            ));
-        }
-
-        // Await the response, optionally bounded by a timeout.
-        let msg = match timeout {
-            Some(duration) => {
-                match time::timeout(duration, rx).await {
-                    Ok(Ok(msg)) => msg,
-                    Ok(Err(_)) => {
-                        // Channel closed without a reply – remove the pending entry.
-                        let mut guard = self.pending.lock().await;
-                        guard.remove(&id);
-                        return Err(anyhow!(
-                            "response channel closed before a reply was received"
-                        ));
-                    }
-                    Err(_) => {
-                        // Timed out. Remove the pending entry so we don't leak.
-                        let mut guard = self.pending.lock().await;
-                        guard.remove(&id);
-                        return Err(anyhow!("request timed out"));
-                    }
+        let client = match client {
+            Some(existing) => existing,
+            None => {
+                let mut builder = reqwest::Client::builder();
+                if let Some(headers) = headers.clone() {
+                    builder = builder.default_headers(headers);
                 }
+                builder.build().context("building reqwest client")?
             }
-            None => rx
-                .await
-                .map_err(|_| anyhow!("response channel closed before a reply was received"))?,
         };
 
-        match msg {
-            JSONRPCMessage::Response(JSONRPCResponse { result, .. }) => {
-                let typed: R::Result = serde_json::from_value(result)?;
-                Ok(typed)
-            }
-            JSONRPCMessage::Error(err) => Err(anyhow!(format!(
-                "server returned JSON-RPC error: code = {}, message = {}",
-                err.error.code, err.error.message
-            ))),
-            other => Err(anyhow!(format!(
-                "unexpected message variant received in reply path: {:?}",
-                other
-            ))),
-        }
+        let transport = StreamableHttpClientTransport::with_client(client, config);
+        Self::start_with_transport(transport, timeout_duration).await
     }
 
-    pub async fn send_notification<N>(&self, params: N::Params) -> Result<()>
-    where
-        N: ModelContextProtocolNotification,
-        N::Params: Serialize,
-    {
-        // Serialize params -> JSON. For many request types `Params` is
-        // `Option<T>` and `None` should be encoded as *absence* of the field.
-        let params_json = serde_json::to_value(&params)?;
-        let params_field = if params_json.is_null() {
-            None
-        } else {
-            Some(params_json)
-        };
+    /// Subscribe to notifications emitted by the connected server.
+    pub fn subscribe_notifications(&self) -> broadcast::Receiver<ServerNotification> {
+        self.inner.notifications.subscribe()
+    }
 
-        let method = N::METHOD.to_string();
-        let jsonrpc_notification = JSONRPCNotification {
-            jsonrpc: JSONRPC_VERSION.to_string(),
-            method: method.clone(),
-            params: params_field,
-        };
-
-        let notification = JSONRPCMessage::Notification(jsonrpc_notification);
-        self.outgoing_tx
-            .send(notification)
+    /// List every tool exposed by the server, automatically following pagination.
+    pub async fn list_all_tools(&self) -> Result<Vec<mcp_types::Tool>> {
+        let tools = self
+            .peer()
+            .list_all_tools()
             .await
-            .with_context(|| format!("failed to send notification `{method}` to writer task"))
+            .map_err(|err| anyhow!(err))?;
+        tools.into_iter().map(convert_value).collect()
     }
 
-    /// Negotiates the initialization with the MCP server. Sends an `initialize`
-    /// request with the specified `initialize_params` and then the
-    /// `notifications/initialized` notification once the response has been
-    /// received. Returns the response to the `initialize` request.
-    pub async fn initialize(
-        &self,
-        initialize_params: InitializeRequestParams,
-        initialize_notification_params: Option<serde_json::Value>,
-        timeout: Option<Duration>,
-    ) -> Result<mcp_types::InitializeResult> {
-        let response = self
-            .send_request::<InitializeRequest>(initialize_params, timeout)
-            .await?;
-        self.send_notification::<InitializedNotification>(initialize_notification_params)
-            .await?;
-        Ok(response)
-    }
-
-    /// Convenience wrapper around `tools/list`.
-    pub async fn list_tools(
-        &self,
-        params: Option<ListToolsRequestParams>,
-        timeout: Option<Duration>,
-    ) -> Result<ListToolsResult> {
-        self.send_request::<ListToolsRequest>(params, timeout).await
-    }
-
-    /// Convenience wrapper around `tools/call`.
+    /// Invoke a tool by name with optional JSON arguments.
     pub async fn call_tool(
         &self,
-        name: String,
+        tool_name: String,
         arguments: Option<serde_json::Value>,
-        timeout: Option<Duration>,
+        timeout_duration: Option<Duration>,
     ) -> Result<mcp_types::CallToolResult> {
-        let params = CallToolRequestParams { name, arguments };
-        debug!("MCP tool call: {params:?}");
-        self.send_request::<CallToolRequest>(params, timeout).await
-    }
+        let params = CallToolRequestParam {
+            name: tool_name.clone().into(),
+            arguments: arguments
+                .map(value_to_json_object)
+                .transpose()
+                .with_context(|| format!("invalid arguments for tool `{tool_name}`"))?,
+        };
 
-    /// Internal helper: route a JSON-RPC *response* object to the pending map.
-    async fn dispatch_response(
-        resp: JSONRPCResponse,
-        pending: &Arc<Mutex<HashMap<i64, PendingSender>>>,
-    ) {
-        let id = match resp.id {
-            RequestId::Integer(i) => i,
-            RequestId::String(_) => {
-                // We only ever generate integer IDs. Receiving a string here
-                // means we will not find a matching entry in `pending`.
-                error!("response with string ID - no matching pending request");
-                return;
+        let result = if let Some(timeout_duration) = timeout_duration {
+            let request = CallToolRequest::new(params.clone());
+            let handle = self
+                .peer()
+                .send_request_with_option(
+                    ClientRequest::CallToolRequest(request),
+                    PeerRequestOptions {
+                        timeout: Some(timeout_duration),
+                        meta: None,
+                    },
+                )
+                .await
+                .map_err(|err| anyhow!(err))?;
+            match handle.await_response().await.map_err(|err| anyhow!(err))? {
+                ServerResult::CallToolResult(result) => result,
+                other => return Err(anyhow!("unexpected response variant: {other:?}")),
             }
+        } else {
+            self.peer()
+                .call_tool(params)
+                .await
+                .map_err(|err| anyhow!(err))?
         };
 
-        let tx_opt = {
-            let mut guard = pending.lock().await;
-            guard.remove(&id)
-        };
-        if let Some(tx) = tx_opt {
-            // Ignore send errors – the receiver might have been dropped.
-            let _ = tx.send(JSONRPCMessage::Response(resp));
-        } else {
-            warn!(id, "no pending request found for response");
-        }
+        convert_value(result)
     }
 
-    /// Internal helper: route a JSON-RPC *error* object to the pending map.
-    async fn dispatch_error(
-        err: mcp_types::JSONRPCError,
-        pending: &Arc<Mutex<HashMap<i64, PendingSender>>>,
-    ) {
-        let id = match err.id {
-            RequestId::Integer(i) => i,
-            RequestId::String(_) => return, // see comment above
-        };
+    /// Send an arbitrary request to the server using raw MCP model types.
+    pub async fn send_request(&self, request: ClientRequest) -> Result<ServerResult> {
+        self.peer()
+            .send_request(request)
+            .await
+            .map_err(|err| anyhow!(err))
+    }
 
-        let tx_opt = {
-            let mut guard = pending.lock().await;
-            guard.remove(&id)
-        };
-        if let Some(tx) = tx_opt {
-            let _ = tx.send(JSONRPCMessage::Error(err));
+    /// Send a notification to the server using raw MCP model types.
+    pub async fn send_notification(&self, notification: ClientNotification) -> Result<()> {
+        self.peer()
+            .send_notification(notification)
+            .await
+            .map_err(|err| anyhow!(err))
+    }
+
+    fn peer(&self) -> &Peer<RoleClient> {
+        self.inner.running_service.peer()
+    }
+
+    async fn start_with_transport<T, E, A>(transport: T, timeout_duration: Duration) -> Result<Self>
+    where
+        T: IntoTransport<RoleClient, E, A>,
+        E: std::error::Error + Send + Sync + 'static,
+    {
+        let (notifications, _) = broadcast::channel(NOTIFICATION_CHANNEL_CAPACITY);
+        let service = CodexClientService::new(notifications.clone());
+        let running_service = timeout(timeout_duration, service.serve(transport))
+            .await
+            .map_err(|_| anyhow!("timed out waiting for MCP client initialization"))?
+            .map_err(|err| anyhow!(err))?;
+
+        Ok(Self {
+            inner: Arc::new(McpClientInner {
+                running_service,
+                notifications,
+            }),
+        })
+    }
+}
+
+struct CodexClientService {
+    client_info: ClientInfo,
+    notifications: broadcast::Sender<ServerNotification>,
+}
+
+impl CodexClientService {
+    fn new(notifications: broadcast::Sender<ServerNotification>) -> Self {
+        Self {
+            client_info: codex_client_info(),
+            notifications,
         }
     }
 }
 
-impl Drop for McpClient {
-    fn drop(&mut self) {
-        // Even though we have already tagged this process with
-        // `kill_on_drop(true)` above, this extra check has the benefit of
-        // forcing the process to be reaped immediately if it has already exited
-        // instead of waiting for the Tokio runtime to reap it later.
-        let _ = self.child.try_wait();
+impl Service<RoleClient> for CodexClientService {
+    async fn handle_request(
+        &self,
+        request: ServerRequest,
+        _context: RequestContext<RoleClient>,
+    ) -> Result<ClientResult, McpError> {
+        match request {
+            ServerRequest::PingRequest(_) => Ok(ClientResult::empty(())),
+            ServerRequest::CreateMessageRequest(_) => {
+                Err(McpError::method_not_found::<CreateMessageRequestMethod>())
+            }
+            ServerRequest::ListRootsRequest(_) => {
+                Ok(ClientResult::ListRootsResult(ListRootsResult::default()))
+            }
+            ServerRequest::CreateElicitationRequest(_) => Ok(
+                ClientResult::CreateElicitationResult(CreateElicitationResult {
+                    action: ElicitationAction::Decline,
+                    content: None,
+                }),
+            ),
+        }
+    }
+
+    fn handle_notification(
+        &self,
+        notification: ServerNotification,
+        _context: NotificationContext<RoleClient>,
+    ) -> impl std::future::Future<Output = Result<(), McpError>> + Send + '_ {
+        let tx = self.notifications.clone();
+        async move {
+            if let Err(err) = tx.send(notification) {
+                debug!("dropping server notification; no active subscribers: {err}");
+            }
+            Ok(())
+        }
+    }
+
+    fn get_info(&self) -> ClientInfo {
+        self.client_info.clone()
+    }
+}
+
+fn codex_client_info() -> ClientInfo {
+    ClientInfo {
+        protocol_version: parse_protocol_version(mcp_types::MCP_SCHEMA_VERSION),
+        capabilities: ClientCapabilities {
+            experimental: None,
+            roots: None,
+            sampling: None,
+            elicitation: Some(ElicitationCapability::default()),
+        },
+        client_info: Implementation {
+            name: "codex-mcp-client".to_owned(),
+            title: Some("Codex".to_owned()),
+            version: env!("CARGO_PKG_VERSION").to_owned(),
+            icons: None,
+            website_url: None,
+        },
+    }
+}
+
+fn parse_protocol_version(version: &str) -> ProtocolVersion {
+    serde_json::from_str::<ProtocolVersion>(&format!("\"{version}\""))
+        .unwrap_or(ProtocolVersion::LATEST)
+}
+
+fn convert_value<T, U>(value: T) -> Result<U>
+where
+    T: Serialize,
+    U: DeserializeOwned,
+{
+    let json = serde_json::to_value(value)?;
+    Ok(serde_json::from_value(json)?)
+}
+
+fn value_to_json_object(value: serde_json::Value) -> Result<JsonObject> {
+    match value {
+        serde_json::Value::Object(map) => Ok(map),
+        other => Err(anyhow!(
+            "expected arguments to be a JSON object, got {other}"
+        )),
     }
 }
 
@@ -409,23 +329,12 @@ impl Drop for McpClient {
 #[rustfmt::skip]
 #[cfg(unix)]
 const DEFAULT_ENV_VARS: &[&str] = &[
-    // https://modelcontextprotocol.io/docs/tools/debugging#environment-variables
-    // states:
-    //
-    // > MCP servers inherit only a subset of environment variables automatically,
-    // > like `USER`, `HOME`, and `PATH`.
-    //
-    // But it does not fully enumerate the list. Empirically, when spawning a
-    // an MCP server via Claude Desktop on macOS, it reports the following
-    // environment variables:
     "HOME",
     "LOGNAME",
     "PATH",
     "SHELL",
     "USER",
     "__CF_USER_TEXT_ENCODING",
-
-    // Additional environment variables Codex chooses to include by default:
     "LANG",
     "LC_ALL",
     "TERM",
@@ -435,7 +344,6 @@ const DEFAULT_ENV_VARS: &[&str] = &[
 
 #[cfg(windows)]
 const DEFAULT_ENV_VARS: &[&str] = &[
-    // TODO: More research is necessary to curate this list.
     "PATH",
     "PATHEXT",
     "USERNAME",
@@ -463,6 +371,7 @@ fn create_env_for_mcp_server(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use pretty_assertions::assert_eq;
 
     #[test]
     fn test_create_env_for_mcp_server() {

--- a/codex-rs/mcp-client/tests/http_client.rs
+++ b/codex-rs/mcp-client/tests/http_client.rs
@@ -1,0 +1,153 @@
+use std::time::Duration;
+
+use anyhow::Result;
+use axum::Router;
+use codex_mcp_client::McpClient;
+use pretty_assertions::assert_eq;
+use rmcp::handler::server::ServerHandler;
+use rmcp::model::CallToolRequestParam;
+use rmcp::model::CallToolResult;
+use rmcp::model::InitializeResult;
+use rmcp::model::ListToolsResult;
+use rmcp::model::Tool;
+use rmcp::service::NotificationContext;
+use rmcp::service::RequestContext;
+use rmcp::service::RoleServer;
+use rmcp::transport::streamable_http_server::StreamableHttpServerConfig;
+use rmcp::transport::streamable_http_server::StreamableHttpService;
+use rmcp::transport::streamable_http_server::session::local::LocalSessionManager;
+use serde_json::json;
+use tokio::sync::oneshot;
+use tokio::time::timeout;
+
+#[derive(Clone, Default)]
+struct TestServer;
+
+impl ServerHandler for TestServer {
+    fn get_info(&self) -> InitializeResult {
+        InitializeResult {
+            protocol_version: rmcp::model::ProtocolVersion::LATEST,
+            capabilities: rmcp::model::ServerCapabilities::builder()
+                .enable_tools()
+                .enable_tool_list_changed()
+                .build(),
+            server_info: rmcp::model::Implementation {
+                name: "test-server".to_string(),
+                title: Some("Test Server".to_string()),
+                version: "0.1.0".to_string(),
+                icons: None,
+                website_url: None,
+            },
+            instructions: None,
+        }
+    }
+
+    fn list_tools(
+        &self,
+        _request: Option<rmcp::model::PaginatedRequestParam>,
+        _context: RequestContext<RoleServer>,
+    ) -> impl std::future::Future<Output = Result<ListToolsResult, rmcp::ErrorData>> + Send + '_
+    {
+        let tool: Tool = serde_json::from_value(json!({
+            "name": "echo",
+            "title": "Echo",
+            "description": "Echo back the provided text.",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "text": { "type": "string" }
+                },
+                "required": ["text"]
+            }
+        }))
+        .unwrap_or_else(|err| panic!("valid tool schema: {err}"));
+        std::future::ready(Ok(ListToolsResult {
+            tools: vec![tool],
+            next_cursor: None,
+        }))
+    }
+
+    async fn call_tool(
+        &self,
+        request: CallToolRequestParam,
+        context: RequestContext<RoleServer>,
+    ) -> Result<CallToolResult, rmcp::ErrorData> {
+        let _ = context.peer.notify_tool_list_changed().await;
+        let text_argument = request
+            .arguments
+            .and_then(|map| map.get("text").cloned())
+            .and_then(|value| value.as_str().map(std::borrow::ToOwned::to_owned))
+            .unwrap_or_default();
+        let response: CallToolResult = serde_json::from_value(json!({
+            "content": [
+                {
+                    "type": "text",
+                    "text": format!("echo: {text_argument}")
+                }
+            ]
+        }))
+        .unwrap_or_else(|err| panic!("valid call tool result: {err}"));
+        Ok(response)
+    }
+
+    fn on_progress(
+        &self,
+        _params: rmcp::model::ProgressNotificationParam,
+        _context: NotificationContext<RoleServer>,
+    ) -> impl std::future::Future<Output = ()> + Send + '_ {
+        std::future::ready(())
+    }
+}
+
+#[tokio::test]
+async fn http_client_connects_and_receives_notifications() -> Result<()> {
+    let service: StreamableHttpService<TestServer, LocalSessionManager> =
+        StreamableHttpService::new(
+            || Ok(TestServer),
+            Default::default(),
+            StreamableHttpServerConfig {
+                stateful_mode: true,
+                sse_keep_alive: None,
+            },
+        );
+
+    let router = Router::new().nest_service("/mcp", service);
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await?;
+    let addr = listener.local_addr()?;
+    let (shutdown_tx, shutdown_rx) = oneshot::channel::<()>();
+    let server_handle = tokio::spawn(async move {
+        let _ = axum::serve(listener, router)
+            .with_graceful_shutdown(async move {
+                let _ = shutdown_rx.await;
+            })
+            .await;
+    });
+
+    let url = format!("http://{addr}/mcp");
+    let client = McpClient::connect_http(url, None, None, None, Duration::from_secs(5)).await?;
+
+    let tools = client.list_all_tools().await?;
+    assert_eq!(tools.len(), 1);
+    assert_eq!(tools[0].name, "echo");
+
+    let mut notifications = client.subscribe_notifications();
+    let result = client
+        .call_tool(
+            "echo".to_string(),
+            Some(json!({ "text": "hello" })),
+            Some(Duration::from_secs(5)),
+        )
+        .await?;
+    assert_eq!(result.content.len(), 1);
+
+    let notification = timeout(Duration::from_secs(5), notifications.recv()).await??;
+    match notification {
+        rmcp::model::ServerNotification::ToolListChangedNotification(_) => {}
+        other => panic!("unexpected notification: {other:?}"),
+    }
+
+    drop(client);
+    shutdown_tx.send(()).ok();
+    server_handle.await.ok();
+    Ok(())
+}

--- a/codex-rs/mcp-client/tests/http_client.rs
+++ b/codex-rs/mcp-client/tests/http_client.rs
@@ -116,11 +116,12 @@ async fn http_client_connects_and_receives_notifications() -> Result<()> {
     let addr = listener.local_addr()?;
     let (shutdown_tx, shutdown_rx) = oneshot::channel::<()>();
     let server_handle = tokio::spawn(async move {
-        let _ = axum::serve(listener, router)
+        axum::serve(listener, router)
             .with_graceful_shutdown(async move {
-                let _ = shutdown_rx.await;
+                shutdown_rx.await.expect("shutdown signal receiver error");
             })
-            .await;
+            .await
+            .expect("axum server error");
     });
 
     let url = format!("http://{addr}/mcp");

--- a/codex-rs/mcp-client/tests/http_client.rs
+++ b/codex-rs/mcp-client/tests/http_client.rs
@@ -149,6 +149,6 @@ async fn http_client_connects_and_receives_notifications() -> Result<()> {
 
     drop(client);
     shutdown_tx.send(()).ok();
-    server_handle.await.ok();
+    server_handle.await.unwrap();
     Ok(())
 }


### PR DESCRIPTION
## Summary
- replace the bespoke JSON-RPC client with the rmcp SDK and expose stdio/HTTP constructors, notification subscription, and helper APIs
- update the core connection manager to rely on the rmcp handshake, aggregate tool listings, and log streamed notifications
- add an HTTP integration test that exercises the new transport helpers and notification flow

## Testing
- `cargo clippy -p codex-mcp-client --all-targets --all-features -- -D warnings`
- `cargo clippy -p codex-core --all-targets --all-features -- -D warnings`
- `cargo test -p codex-mcp-client`
- `cargo test -p codex-core` *(aborted integration suite after unit tests due to runtime)*

------
https://chatgpt.com/codex/tasks/task_b_68d6aa17a710832a9f4612a1e562fa6b