### PR TITLE
Adjust MCP client call_tool timeout handling

### DIFF
--- a/codex-rs/mcp-client/src/mcp_client.rs
+++ b/codex-rs/mcp-client/src/mcp_client.rs
@@ -172,11 +172,11 @@ impl McpClient {
                 .await
                 .map_err(|err| anyhow!(err))?;
 
-            match handle.await_response().await {
-                Ok(ServerResult::CallToolResult(result)) => result,
-                Ok(other) => return Err(anyhow!("unexpected response variant: {other:?}")),
-                Err(err) => return Err(anyhow!(err)),
-            }
+            let server_result = handle.await_response().await.map_err(anyhow::Error::from)?;
+            let ServerResult::CallToolResult(result) = server_result else {
+                return Err(anyhow!("unexpected response variant: {server_result:?}"));
+            };
+            result
         } else {
             self.peer()
                 .call_tool(params)

--- a/codex-rs/mcp-client/src/mcp_client.rs
+++ b/codex-rs/mcp-client/src/mcp_client.rs
@@ -158,13 +158,24 @@ impl McpClient {
                 .with_context(|| format!("invalid arguments for tool `{tool_name}`"))?,
         };
 
-            match tokio::time::timeout(timeout_duration, handle.await_response()).await {
-                Ok(Ok(ServerResult::CallToolResult(result))) => result,
-                Ok(Ok(other)) => return Err(anyhow!("unexpected response variant: {other:?}")),
-                Ok(Err(err)) => return Err(anyhow!(err)),
-                Err(_) => return Err(anyhow!("request timed out")),
-            }
-                other => return Err(anyhow!("unexpected response variant: {other:?}")),
+        let result = if let Some(timeout_duration) = timeout_duration {
+            let request = CallToolRequest::new(params.clone());
+            let handle = self
+                .peer()
+                .send_cancellable_request(
+                    ClientRequest::CallToolRequest(request),
+                    PeerRequestOptions {
+                        timeout: Some(timeout_duration),
+                        ..PeerRequestOptions::default()
+                    },
+                )
+                .await
+                .map_err(|err| anyhow!(err))?;
+
+            match handle.await_response().await {
+                Ok(ServerResult::CallToolResult(result)) => result,
+                Ok(other) => return Err(anyhow!("unexpected response variant: {other:?}")),
+                Err(err) => return Err(anyhow!(err)),
             }
         } else {
             self.peer()


### PR DESCRIPTION
## Summary
- adjust the cancellable call_tool path to await the rmcp handle directly
- ensure rmcp timeout errors bubble up unchanged while still validating the response variant

## Testing
- `just fmt`
- `just fix -p codex-mcp-client`
- `cargo test -p codex-mcp-client`


------
https://chatgpt.com/codex/tasks/task_b_68d70bbf2e94832a87cd4ec40efd558a