### PR TITLE
Log skipped MCP notification counts

### DIFF
--- a/codex-rs/core/src/mcp_connection_manager.rs
+++ b/codex-rs/core/src/mcp_connection_manager.rs
@@ -20,6 +20,7 @@ use mcp_types::Tool;
 
 use sha1::Digest;
 use sha1::Sha1;
+use tokio::sync::broadcast::error::RecvError;
 use tokio::task::JoinSet;
 use tokio::time::timeout;
 use tracing::debug;
@@ -177,21 +178,31 @@ impl McpConnectionManager {
                     let mut notifications = client.subscribe_notifications();
                     let server_name_clone = server_name.clone();
                     let notification_task = tokio::spawn(async move {
-                        while let Ok(notification) = notifications.recv().await {
-                            match serde_json::to_value(&notification) {
-                                Ok(value) => {
-                                    debug!(
+                        loop {
+                            match notifications.recv().await {
+                                Ok(notification) => match serde_json::to_value(&notification) {
+                                    Ok(value) => {
+                                        debug!(
+                                            server = %server_name_clone,
+                                            notification = %value,
+                                            "received MCP notification"
+                                        );
+                                    }
+                                    Err(_) => {
+                                        debug!(
+                                            server = %server_name_clone,
+                                            "received MCP notification"
+                                        );
+                                    }
+                                },
+                                Err(RecvError::Lagged(skipped)) => {
+                                    warn!(
                                         server = %server_name_clone,
-                                        notification = %value,
-                                        "received MCP notification"
+                                        skipped = skipped,
+                                        "skipped MCP notifications due to lag"
                                     );
                                 }
-                                Err(_) => {
-                                    debug!(
-                                        server = %server_name_clone,
-                                        "received MCP notification"
-                                    );
-                                }
+                                Err(RecvError::Closed) => break,
                             }
                         }
                     });

--- a/codex-rs/mcp-client/src/mcp_client.rs
+++ b/codex-rs/mcp-client/src/mcp_client.rs
@@ -158,13 +158,24 @@ impl McpClient {
                 .with_context(|| format!("invalid arguments for tool `{tool_name}`"))?,
         };
 
-            match tokio::time::timeout(timeout_duration, handle.await_response()).await {
-                Ok(Ok(ServerResult::CallToolResult(result))) => result,
-                Ok(Ok(other)) => return Err(anyhow!("unexpected response variant: {other:?}")),
-                Ok(Err(err)) => return Err(anyhow!(err)),
-                Err(_) => return Err(anyhow!("request timed out")),
-            }
-                other => return Err(anyhow!("unexpected response variant: {other:?}")),
+        let result = if let Some(timeout_duration) = timeout_duration {
+            let options = PeerRequestOptions {
+                timeout: Some(timeout_duration),
+                meta: None,
+            };
+            let handle = self
+                .peer()
+                .send_cancellable_request(
+                    ClientRequest::CallToolRequest(CallToolRequest::new(params)),
+                    options,
+                )
+                .await
+                .map_err(|err| anyhow!(err))?;
+
+            match handle.await_response().await {
+                Ok(ServerResult::CallToolResult(result)) => result,
+                Ok(other) => return Err(anyhow!("unexpected response variant: {other:?}")),
+                Err(err) => return Err(anyhow!(err)),
             }
         } else {
             self.peer()


### PR DESCRIPTION
## Summary
- ensure lagged MCP notifications log the number of skipped messages
- fix the MCP client call_tool timeout handling so optional request timeouts build and run correctly

## Testing
- just fmt
- cargo test -p codex-mcp-client
- cargo test -p codex-core *(fails: suite::client::azure_overrides_assign_properties_used_for_responses_url and suite::client::env_var_overrides_loaded_auth require Azure environment configuration)*

------
https://chatgpt.com/codex/tasks/task_b_68d70bc0881c832a86ad8e98e27e5d80